### PR TITLE
Replace django.utils.simplejson with json

### DIFF
--- a/django_mongokit/forms/fields.py
+++ b/django_mongokit/forms/fields.py
@@ -2,7 +2,13 @@
 from django.forms.fields import CharField, ValidationError
 from django.forms.widgets import TextInput, Textarea
 
-from django.utils import simplejson
+try:
+    import json as simplejson
+except ImportError, e:
+    if e.args[0].startswith('No module named json'):
+        from django.utils import simplejson
+    else:
+        raise
 
 
 class JsonField(CharField):

--- a/django_mongokit/forms/fields.py
+++ b/django_mongokit/forms/fields.py
@@ -1,14 +1,9 @@
+# coding: utf-8
+
+import json
 
 from django.forms.fields import CharField, ValidationError
 from django.forms.widgets import TextInput, Textarea
-
-try:
-    import json as simplejson
-except ImportError, e:
-    if e.args[0].startswith('No module named json'):
-        from django.utils import simplejson
-    else:
-        raise
 
 
 class JsonField(CharField):
@@ -24,7 +19,7 @@ class JsonField(CharField):
             return {}
 
         try:
-            return simplejson.loads(value)
+            return json.loads(value)
         except ValueError, e:
             raise ValidationError(str(e))
 
@@ -42,6 +37,6 @@ class JsonListField(CharField):
             return []
 
         try:
-            return simplejson.loads(value)
+            return json.loads(value)
         except ValueError, e:
             raise ValidationError(str(e))

--- a/django_mongokit/forms/forms.py
+++ b/django_mongokit/forms/forms.py
@@ -1,6 +1,12 @@
 import datetime
 from django import forms
-from django.utils import simplejson
+try:
+    import json as simplejson
+except ImportError, e:
+    if e.args[0].startswith('No module named json'):
+        from django.utils import simplejson
+    else:
+        raise
 
 from django.utils.datastructures import SortedDict
 from django.forms.util import ErrorList

--- a/django_mongokit/forms/forms.py
+++ b/django_mongokit/forms/forms.py
@@ -1,12 +1,6 @@
 import datetime
 from django import forms
-try:
-    import json as simplejson
-except ImportError, e:
-    if e.args[0].startswith('No module named json'):
-        from django.utils import simplejson
-    else:
-        raise
+import json
 
 from django.utils.datastructures import SortedDict
 from django.forms.util import ErrorList
@@ -54,7 +48,7 @@ def value_from_document(instance, field_name):
 
     # Refactor this into a class for each data type.
     if field_type in [list, dict]:
-        return simplejson.dumps(instance[field_name])
+        return json.dumps(instance[field_name])
 
     return instance[field_name]
 


### PR DESCRIPTION
In  Python 2.5, json module was build-in.  

And simplejson in django.utils was removed in Django 1.5.  

So if we use django 1.5+ ,it will case import error.  

So I try to change it into import json.

Look: http://stackoverflow.com/questions/28048943/cannot-import-name-simplejson-after-installing-simplejson

Thanks